### PR TITLE
no id required

### DIFF
--- a/js/jquery.taghandler.js
+++ b/js/jquery.taghandler.js
@@ -155,12 +155,6 @@
                 next;
             }
 
-            // adds an id to the tagContainer in case it doesn't have one
-            if (!this.id) {
-                var d = new Date();
-                this.id = d.getTime();
-            }
-
             var tagContainer = this;
 
             // wraps the <ul> element in a div mainly for use in positioning
@@ -286,7 +280,7 @@
             if (opts.allowEdit) {
                 // delegates a click event function to all future <li> elements with
                 // the tagItem class that will remove the tag upon click
-                $(tagContainer).delegate("#" + this.id + " li.tagItem", "click",
+                $(tagContainer).delegate("li.tagItem", "click",
                 function() {
                     tags = removeTag($(this), tags, opts.sortTags);
                     if (opts.updateURL != '' && opts.autoUpdate) {


### PR DESCRIPTION
Hi Mark,

I recently find your great plugin and it most exactly matches.
However, I think I've found an issue.

With the following code, I'm trying to put a tagHandler on a newly created `<ul>` element. Everything works fine except the tag removal :

```
$('<ul>').appendTo(document.body)
        .tagHandler({
    assignedTags: ['something'],
    availableTags: ['autre', 'toto'],
    autocomplete: true
});
```

I can't really figure out why but no `click` event listener seem to be correctly append to the `<li.tagItem>` elements.

Looking at your code, I first figured out that removing the `this.id` section in the event delegation helps a lot with no apparent regression.

I hope this helps.
