### PR TITLE
Added optional afterAdd and afterDelete callbacks

### DIFF
--- a/README
+++ b/README
@@ -1,4 +1,4 @@
-jQuery Tag Handler v1.2.1
+jQuery Tag Handler v1.2.2
 Copyright (C) 2010-2011 Mark Jubenville
 Mark Jubenville - ioncache@gmail.com
 http://ioncache.github.com/Tag-Handler
@@ -126,6 +126,8 @@ Option          Description                                     Default Value
 --------------  ----------------------------------------------  --------------
 onAdd           function to be called when a new tag is added   {}
 onDelete        function to be called when a tag is deleted     {}
+afterAdd        function to be called after a new tag is added  {}
+afterDelete     function to be called after a tag is deleted    {}
 
 Miscellaneous options:
 ----------------------

--- a/js/jquery.taghandler.js
+++ b/js/jquery.taghandler.js
@@ -1,5 +1,5 @@
 /*
-jQuery Tag Handler v1.2.1
+jQuery Tag Handler v1.2.2
 Copyright (C) 2010-2011 Mark Jubenville
 Mark Jubenville - ioncache@gmail.com
 http://ioncache.github.com/Tag-Handler


### PR DESCRIPTION
I required a callback to be available _after_ tags were added/deleted so that when I called getTags I could see the updated values.

This pull request contains two additional callbacks, afterAdd and afterDelete. I also bumped the version to 1.2.2 and updated the README (and the docs inside the JS file).

I have not re-minified the source as I'm not sure what tool you use for that.
